### PR TITLE
Feat/Add user-withdrawal API

### DIFF
--- a/backend/user/backends.py
+++ b/backend/user/backends.py
@@ -13,4 +13,3 @@ class EmailBackend(ModelBackend):
             if user.check_password(password):
                 return user
         return None
-

--- a/backend/user/urls.py
+++ b/backend/user/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     path('profile/', views.UserProfileView.as_view(), name='get profile'),
     path('profile/nickname/', views.NicknameUpdateView.as_view(), name='change nickname'),
     path('profile/password/', views.PasswordUpdateView.as_view(), name='change password'),
+    path('withdraw/', views.UserWithdrawView.as_view(), name='withdraw')
 ]

--- a/backend/user/views.py
+++ b/backend/user/views.py
@@ -167,3 +167,19 @@ class NicknameUpdateView(APIView):
         nickname_serializer.is_valid(raise_exception=True)
         nickname_serializer.save()
         return Response(status=status.HTTP_200_OK)
+
+
+class UserWithdrawView(APIView):
+    permission_classes = (permissions.IsAuthenticated, )
+
+    def post(self, request):
+        # Don't know why, but if we attempt to delete the user after blacklisting the token,
+        # the blacklisting doesn't work properly as expected
+        request.user.delete()
+
+        serializer = UserLogoutSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        refresh_token = RefreshToken(serializer.validated_data['refresh'])
+        refresh_token.blacklist()
+
+        return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
### PR Title: Implemented user-withdrawal API

#### Related Issue(s):
I first tried to set `is_active` field of `user` as False to handle user-withdrawal.
But when I embarked on implementing the withdrawal feature,
I found out that user-related data (custom symbols, favorites, weight tables, etc.), which was of no use to keep after a user quit our service, was not automatically deleted if I didn't delete the user object.
Deleting a user object from DB automatically leads to deleting related data. (Although the data structure can be substantially modified later in iteration 3.)

There can be some benefits of keeping unregistered-user objects in the DB (reference: [benefits](https://velog.io/@nikevapormax/0816-회원탈퇴-피드백))
but I think we don't need such benefits since we don't offer special services to rejoining users.

So I thought deleting a user object would be a better choice, rather than keeping the object with `is_active` field as False.
Any feedbacks are welcomed..☺️

#### PR Description:
added new URL
added corresponding user-withdrawal feature (w/ revoking refresh token)

##### Changes Included:
- [x] Added new feature(s)
- [ ] Fixed identified bug(s)
- [x] Updated relevant documentation

##### Notes for Reviewer:

#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

#### Additional Comments: