### PR TITLE
Fix: Change coroutine to execute after response on login

### DIFF
--- a/frontend/app/src/main/java/com/example/speechbuddy/data/remote/models/SettingsBackupDto.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/data/remote/models/SettingsBackupDto.kt
@@ -6,5 +6,6 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class SettingsBackupDto(
     @Json(name = "display_mode") val displayMode: Int? = null,
-    @Json(name = "default_menu") val defaultMenu: Int? = null
+    @Json(name = "default_menu") val defaultMenu: Int? = null,
+    @Json(name = "updated_at") val updatedAt: String? = null
 )

--- a/frontend/app/src/main/java/com/example/speechbuddy/repository/SettingsRepository.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/repository/SettingsRepository.kt
@@ -236,9 +236,9 @@ class SettingsRepository @Inject constructor(
             if (response.isSuccessful && response.code() == ResponseCode.SUCCESS.value) {
                 response.body()?.let { favoritesListDto ->
                     for (symbolIdDto in favoritesListDto.results) {
-                        symbolRepository.getSymbolsById(symbolIdDto.id).collect { symbol ->
-                            symbolRepository.updateFavorite(symbol, true)
-                        }
+                        val symbol = symbolRepository.getSymbolsById(symbolIdDto.id)
+                        symbolRepository.updateFavorite(symbol, true)
+
                     }
                     Resource.success(null)
                 } ?: returnUnknownError()

--- a/frontend/app/src/main/java/com/example/speechbuddy/repository/SettingsRepository.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/repository/SettingsRepository.kt
@@ -175,18 +175,19 @@ class SettingsRepository @Inject constructor(
                 response.body()?.let { settingsDto ->
                     val displayMode = settingsDto.displayMode
                     val defaultMenu = settingsDto.defaultMenu
+                    val updatedAt = settingsDto.updatedAt!!
+                    setLastBackupDate(updatedAt)
                     if (displayMode == 0) {
                         setDarkMode(false)
-                        settingsPrefManager.saveDarkMode(false)
                     } else {
                         setDarkMode(true)
-                        settingsPrefManager.saveDarkMode(true)
                     }
                     if (defaultMenu == 0) {
                         setInitialPage(InitialPage.SYMBOL_SELECTION)
                     } else {
                         setInitialPage(InitialPage.TEXT_TO_SPEECH)
                     }
+
                     Resource.success(null)
                 } ?: returnUnknownError()
             } else {

--- a/frontend/app/src/main/java/com/example/speechbuddy/repository/SymbolRepository.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/repository/SymbolRepository.kt
@@ -77,8 +77,8 @@ class SymbolRepository @Inject constructor(
             symbolEntities.map { symbolEntity -> symbolMapper.mapToDomainModel(symbolEntity) }
         }
 
-    fun getSymbolsById(id: Int) = symbolDao.getSymbolById(id).map { symbolEntity ->
-        symbolMapper.mapToDomainModel(symbolEntity)
+    fun getSymbolsById(id: Int): Symbol {
+        return runBlocking { symbolMapper.mapToDomainModel(symbolDao.getSymbolById(id).first()) }
     }
 
     private fun getAllSymbols() = symbolDao.getSymbols().map { symbolEntities ->
@@ -108,16 +108,19 @@ class SymbolRepository @Inject constructor(
         return if (idList.isEmpty()) "" else idList.joinToString(separator = ",")
     }
 
-    suspend fun updateFavorite(symbol: Symbol, value: Boolean) {
-        val symbolEntity = SymbolEntity(
-            id = symbol.id,
-            text = symbol.text,
-            imageUrl = symbol.imageUrl,
-            categoryId = symbol.categoryId,
-            isFavorite = value,
-            isMine = symbol.isMine
-        )
-        symbolDao.updateSymbol(symbolEntity)
+    fun updateFavorite(symbol: Symbol, value: Boolean) {
+        runBlocking {
+            val symbolEntity = SymbolEntity(
+                id = symbol.id,
+                text = symbol.text,
+                imageUrl = symbol.imageUrl,
+                categoryId = symbol.categoryId,
+                isFavorite = value,
+                isMine = symbol.isMine
+            )
+            symbolDao.updateSymbol(symbolEntity)
+        }
+
     }
 
     fun getNextSymbolId() =
@@ -127,9 +130,11 @@ class SymbolRepository @Inject constructor(
         /* TODO: 내가 만든 상징들 모두 삭제 */
     }
 
-    suspend fun insertSymbol(symbol: Symbol) {
-        val symbolEntity = symbolMapper.mapFromDomainModel(symbol)
-        symbolDao.insertSymbol(symbolEntity)
+    fun insertSymbol(symbol: Symbol) {
+        runBlocking {
+            val symbolEntity = symbolMapper.mapFromDomainModel(symbol)
+            symbolDao.insertSymbol(symbolEntity)
+        }
     }
 
     suspend fun createSymbolBackup(

--- a/frontend/app/src/main/java/com/example/speechbuddy/viewmodel/SymbolSelectionViewModel.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/viewmodel/SymbolSelectionViewModel.kt
@@ -47,8 +47,8 @@ class SymbolSelectionViewModel @Inject internal constructor(
     private var getEntriesJob: Job? = null
 
     init {
-        getEntries()
         repository.checkImages()
+        getEntries()
     }
 
     fun enterDisplayMax() {


### PR DESCRIPTION
### PR Title: Change coroutine to execute after response on login

#### Related Issue(s):
- 코루틴이 동시에 여러 response를 받으면 터지는 상황을 방지하기 위해 response를 받은 다음 함수를 순차적으로 실행하도록 함
- 로그인시 다운받은 개인이 만든 상징과 즐겨찾기 한 상징들 중 첫번째 상징만 등록되는 현상 수정

#### PR Description:
- Change coroutine to execute after response on login
- Update last update date on login

##### Changes Included:
- [x] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation

##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.

#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
