### PR TITLE
자동 로그인/게스트 모드/설정 화면 관련 버그 수정

### DIFF
--- a/frontend/app/src/main/java/com/example/speechbuddy/compose/symbolselection/DisplayMaxScreen.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/compose/symbolselection/DisplayMaxScreen.kt
@@ -78,7 +78,7 @@ fun DisplayMaxScreen(
                     )
             ) {
                 Box(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.weight(1f),
                     contentAlignment = Alignment.CenterStart
                 ) {
                     LazyRow(

--- a/frontend/app/src/main/java/com/example/speechbuddy/compose/symbolselection/DisplayModeMenu.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/compose/symbolselection/DisplayModeMenu.kt
@@ -88,7 +88,8 @@ fun DisplayModeMenu(
                 ) {
                     Text(
                         text = stringResource(id = item.textResId),
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.bodyMedium
                     )
                 }
             }

--- a/frontend/app/src/main/java/com/example/speechbuddy/compose/symbolselection/SelectedSymbolsBox.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/compose/symbolselection/SelectedSymbolsBox.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -52,7 +52,6 @@ fun SelectedSymbolsBox(
     ) {
         Box(
             modifier = Modifier
-                .fillMaxWidth()
                 .weight(1f),
             contentAlignment = Alignment.CenterStart
         ) {
@@ -70,16 +69,17 @@ fun SelectedSymbolsBox(
             }
         }
 
-        Box(
+        Column(
             modifier = Modifier
                 .width(50.dp)
                 .background(color = MaterialTheme.colorScheme.surface)
+                .padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Button(
                 onClick = onDisplayMax,
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(8.dp),
+                    .weight(1f),
                 enabled = selectedSymbols.isNotEmpty(),
                 shape = RoundedCornerShape(5.dp),
                 colors = ButtonDefaults.buttonColors(
@@ -90,6 +90,25 @@ fun SelectedSymbolsBox(
             ) {
                 Text(
                     text = stringResource(id = R.string.display_max),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+
+            Button(
+                onClick = onClearAll,
+                modifier = Modifier
+                    .weight(1f),
+                enabled = selectedSymbols.isNotEmpty(),
+                shape = RoundedCornerShape(5.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError
+                ),
+                contentPadding = PaddingValues(2.dp)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.clear_all),
                     textAlign = TextAlign.Center,
                     style = MaterialTheme.typography.bodyMedium
                 )

--- a/frontend/app/src/main/java/com/example/speechbuddy/compose/symbolselection/SymbolSelectionScreen.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/compose/symbolselection/SymbolSelectionScreen.kt
@@ -141,9 +141,11 @@ fun SymbolSelectionScreen(
 
     if (uiState.isDisplayMax) {
         hideBottomNavBar()
-        DisplayMaxScreen(onExit = {
-            viewModel.exitDisplayMax()
-            showBottomNavBar()
-        })
+        DisplayMaxScreen(
+            onExit = {
+                viewModel.exitDisplayMax()
+                showBottomNavBar()
+            }
+        )
     }
 }

--- a/frontend/app/src/main/java/com/example/speechbuddy/data/local/AuthTokenPrefsManager.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/data/local/AuthTokenPrefsManager.kt
@@ -36,12 +36,6 @@ class AuthTokenPrefsManager @Inject constructor(context: Context) {
             )
         }
 
-    suspend fun saveAccessToken(token: String) {
-        dataStore.edit { preferences ->
-            preferences[ACCESS] = token
-        }
-    }
-
     suspend fun saveAuthToken(authToken: AuthToken) {
         dataStore.edit { preferences ->
             preferences[ACCESS] = authToken.accessToken ?: ""

--- a/frontend/app/src/main/java/com/example/speechbuddy/data/local/UserIdPrefsManager.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/data/local/UserIdPrefsManager.kt
@@ -1,0 +1,48 @@
+package com.example.speechbuddy.data.local
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.createDataStore
+import com.example.speechbuddy.data.local.UserIdPrefsManager.PreferencesKeys.USER_ID
+import com.example.speechbuddy.utils.Constants.Companion.USER_ID_PREF
+import com.example.speechbuddy.utils.Constants.Companion.USER_ID_PREFS
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+
+class UserIdPrefsManager @Inject constructor(context: Context) {
+
+    private val dataStore = context.createDataStore(name = USER_ID_PREFS)
+
+    val preferencesFlow: Flow<Int> = dataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences ->
+            preferences[USER_ID] ?: -1
+        }
+
+    suspend fun saveUserId(id: Int) {
+        dataStore.edit { preferences ->
+            preferences[USER_ID] = id
+        }
+    }
+
+    suspend fun clearUserId() {
+        dataStore.edit { preferences ->
+            preferences.clear()
+        }
+    }
+
+    private object PreferencesKeys {
+        val USER_ID = intPreferencesKey(USER_ID_PREF)
+    }
+}

--- a/frontend/app/src/main/java/com/example/speechbuddy/di/DatabaseModule.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/di/DatabaseModule.kt
@@ -7,6 +7,7 @@ import com.example.speechbuddy.data.local.CategoryDao
 import com.example.speechbuddy.data.local.SettingsPrefsManager
 import com.example.speechbuddy.data.local.SymbolDao
 import com.example.speechbuddy.data.local.UserDao
+import com.example.speechbuddy.data.local.UserIdPrefsManager
 import com.example.speechbuddy.data.local.models.CategoryMapper
 import com.example.speechbuddy.data.local.models.SymbolMapper
 import com.example.speechbuddy.data.local.models.UserMapper
@@ -82,6 +83,13 @@ class DatabaseModule {
     fun provideAuthTokenPrefsManager(@ApplicationContext context: Context): AuthTokenPrefsManager {
         return AuthTokenPrefsManager(context)
     }
+
+    @Singleton
+    @Provides
+    fun provideUserIdPrefsManager(@ApplicationContext context: Context): UserIdPrefsManager {
+        return UserIdPrefsManager(context)
+    }
+
 
     @Singleton
     @Provides

--- a/frontend/app/src/main/java/com/example/speechbuddy/repository/AuthRepository.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/repository/AuthRepository.kt
@@ -1,6 +1,7 @@
 package com.example.speechbuddy.repository
 
 import com.example.speechbuddy.data.local.AuthTokenPrefsManager
+import com.example.speechbuddy.data.local.SettingsPrefsManager
 import com.example.speechbuddy.data.local.UserIdPrefsManager
 import com.example.speechbuddy.data.remote.AuthTokenRemoteSource
 import com.example.speechbuddy.data.remote.models.AccessTokenDtoMapper
@@ -34,6 +35,7 @@ class AuthRepository @Inject constructor(
     private val authService: AuthService,
     private val userIdPrefsManager: UserIdPrefsManager,
     private val authTokenPrefsManager: AuthTokenPrefsManager,
+    private val settingsPrefsManager: SettingsPrefsManager,
     private val authTokenRemoteSource: AuthTokenRemoteSource,
     private val authTokenDtoMapper: AuthTokenDtoMapper,
     private val accessTokenDtoMapper: AccessTokenDtoMapper,
@@ -147,6 +149,7 @@ class AuthRepository @Inject constructor(
                 CoroutineScope(Dispatchers.IO).launch {
                     userIdPrefsManager.clearUserId()
                     authTokenPrefsManager.clearAuthToken()
+                    settingsPrefsManager.resetSettings()
                 }
                 emit(result)
             } catch (e: Exception) {
@@ -163,6 +166,7 @@ class AuthRepository @Inject constructor(
                 CoroutineScope(Dispatchers.IO).launch {
                     userIdPrefsManager.clearUserId()
                     authTokenPrefsManager.clearAuthToken()
+                    settingsPrefsManager.resetSettings()
                 }
                 emit(result)
             } catch (e: Exception) {

--- a/frontend/app/src/main/java/com/example/speechbuddy/repository/UserRepository.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/repository/UserRepository.kt
@@ -1,6 +1,7 @@
 package com.example.speechbuddy.repository
 
 import com.example.speechbuddy.data.local.UserDao
+import com.example.speechbuddy.data.local.UserIdPrefsManager
 import com.example.speechbuddy.data.local.models.UserMapper
 import com.example.speechbuddy.data.remote.UserRemoteSource
 import com.example.speechbuddy.data.remote.models.UserDtoMapper
@@ -20,6 +21,7 @@ class UserRepository @Inject constructor(
     private val userMapper: UserMapper,
     private val userDtoMapper: UserDtoMapper,
     private val userRemoteSource: UserRemoteSource,
+    private val userIdPrefsManager: UserIdPrefsManager,
     private val responseHandler: ResponseHandler,
     private val sessionManager: SessionManager
 ) {
@@ -36,6 +38,7 @@ class UserRepository @Inject constructor(
             if (response.isSuccessful && response.code() == ResponseCode.SUCCESS.value) {
                 response.body()?.let { userDto ->
                     val user = userDtoMapper.mapToDomainModel(userDto)
+                    userIdPrefsManager.saveUserId(user.id)
                     val userEntity = userMapper.mapFromDomainModel(user)
                     userDao.insertUser(userEntity)
                     Resource.success(user)

--- a/frontend/app/src/main/java/com/example/speechbuddy/utils/Constants.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/utils/Constants.kt
@@ -15,6 +15,9 @@ class Constants {
         const val ACCESS_TOKEN_PREF: String = "com.example.speechbuddy.ACCESS_TOKEN_PREF"
         const val REFRESH_TOKEN_PREF: String = "com.example.speechbuddy.REFRESH_TOKEN_PREF"
 
+        const val USER_ID_PREFS: String = "com.example.speechbuddy.USER_ID_PREFS"
+        const val USER_ID_PREF: String = "com.example.speechbuddy.USER_ID_PREF"
+
         const val SETTINGS_PREFS: String = "com.example.speechbuddy.SETTINGS_PREFS"
         const val AUTO_BACKUP_PREF: String = "com.example.speechbuddy.AUTO_BACKUP_PREF"
         const val DARK_MODE_PREF: String = "com.example.speechbuddy.DARK_MODE_PREF"

--- a/frontend/app/src/main/java/com/example/speechbuddy/viewmodel/LoginViewModel.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/viewmodel/LoginViewModel.kt
@@ -134,7 +134,6 @@ class LoginViewModel @Inject internal constructor(
                             getFavoritesListFromRemote(resource.data.accessToken)
                             getWeightTableFromRemote(resource.data.accessToken)
                         }
-
                     } else if (resource.message?.contains("email", ignoreCase = true) == true) {
                         _uiState.update { currentState ->
                             currentState.copy(
@@ -316,7 +315,10 @@ class LoginViewModel @Inject internal constructor(
     fun checkPreviousUser() {
         viewModelScope.launch {
             authRepository.checkPreviousUser().collect { resource ->
-                if (resource.data != null) sessionManager.setAuthToken(resource.data)
+                if (resource.data != null) {
+                    sessionManager.setUserId(resource.data.first)
+                    sessionManager.setAuthToken(resource.data.second)
+                }
             }
         }
     }

--- a/frontend/app/src/main/res/values/strings.xml
+++ b/frontend/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="currently_selected_menu">현재 선택된 메뉴</string>
     <string name="fill_query">검색어를 입력하세요</string>
     <string name="display_max">크게 보기</string>
-    <string name="clear_all">전체 삭제</string>
+    <string name="clear_all">모두 삭제</string>
     <string name="unselect_symbol">상징 선택 취소</string>
     <string name="exit">나가기</string>
 


### PR DESCRIPTION
### PR Title: [자동 로그인/게스트 모드/설정 화면 관련 버그 수정]

#### Related Issue(s):
Link or reference any related issues or tickets.

#### PR Description:
로그인 후 앱을 껐다 켰을 때 자동 로그인은 되지만 설정 화면이 게스트 모드로 보이는 문제 수정

##### Changes Included:
- [ ] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation

##### Notes for Reviewer:
로그인 성공 후 앱 내에 사용자의 JWT 토큰만 저장하기 때문에 발생한 문제입니다.
유저 정보를 가져온 이후 사용자의 ID도 앱 내의 로컬 저장소(userIdPrefsManager)에 저장하고,
자동 로그인 시도할 때 이 사용자 ID도 읽어와 sessionManager에 저장하게 함으로써 문제를 해결했습니다.

또, 유저 모드와 게스트 모드를 왔다 갔다 할 때 설정 데이터(다크모드 등)가 지워지지 않고 남아있는 문제도 있었는데,
이를 해결하기 위해 로그아웃/회원 탈퇴 시 resetSettings()를 호출하게 함으로써 해결했습니다.
백업이 정상적으로 이루어지고, 자동 로그인 때 정상적으로 불러와진다면 유저의 설정 변경 내역은 잘 보존될 것으로 예상됩니다.

#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
