### PR TITLE
fix/display-mode

### DIFF
--- a/frontend/app/src/main/java/com/example/speechbuddy/HomeActivity.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/HomeActivity.kt
@@ -52,10 +52,10 @@ class HomeActivity : BaseActivity() {
     }
 
     private fun getInitialPage(): Boolean {
-        var initialPage = false
+        var initialPage = true
         lifecycleScope.launch {
             settingsRepository.getInitialPage().collect {
-                initialPage = it.data?: false
+                initialPage = it.data?: true
             }
         }
         return initialPage

--- a/frontend/app/src/main/java/com/example/speechbuddy/repository/SettingsRepository.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/repository/SettingsRepository.kt
@@ -187,7 +187,7 @@ class SettingsRepository @Inject constructor(
                     } else {
                         setDarkMode(true)
                     }
-                    if (defaultMenu == 0) {
+                    if (defaultMenu == 1) {
                         setInitialPage(InitialPage.SYMBOL_SELECTION)
                     } else {
                         setInitialPage(InitialPage.TEXT_TO_SPEECH)


### PR DESCRIPTION
### PR Title: fix/display-mode

#### Related Issue(s):

#### PR Description:
한 가지 문제 빼고는 다 해결했습니다....그 한 가지 문제는 로그인 직후에는 무조건 symbol page로 가게 된다는 것입니다
정보를 받아오는 데 시간이 좀 걸려서 생기는 문제이고, 해결하려고 다음과 같은 방법을 시도해보았습니다
1. suspend 사용: oncreate에서 사용할 수 없음
2. mutable한 자료구조 사용: 처음에 symbol page(기본값)가 좀 보이다가 TTS로 바뀌는 문제 발생, 세팅 페이지에서 display mode를 바꾸는 즉시 SpeechBuddyHome이 불려서 세팅 페이지를 이탈하는 문제 발생

바꾸려면 datastore를 안 쓰는 쪽으로 아예 구조를 엎어야 할 것 같아서 그냥 두겠습니다...로그인 직후를 제외하면 자동 로그인이 일어날 시에는 다 정상 작동하는 것 확인했습니다

##### Changes Included:
- [ ] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation

##### Notes for Reviewer:


#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

#### Additional Comments:
