### PR TITLE
Fix: Weight table update logic

### DIFF
--- a/frontend/app/src/main/java/com/example/speechbuddy/HomeActivity.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/HomeActivity.kt
@@ -3,6 +3,7 @@ package com.example.speechbuddy
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.MotionEvent
 import android.view.inputmethod.InputMethodManager
 import androidx.activity.compose.setContent
@@ -15,6 +16,7 @@ import com.example.speechbuddy.ui.SpeechBuddyTheme
 import com.example.speechbuddy.worker.SeedDatabaseWorker
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import com.example.speechbuddy.utils.Constants.Companion.GUEST_ID
 
 @AndroidEntryPoint
 class HomeActivity : BaseActivity() {
@@ -23,10 +25,15 @@ class HomeActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
 
         super.onCreate(savedInstanceState)
-        // force the database worker to build a new db
-        // in order to check if the weight-db is empty or not and fill it
-        val request = OneTimeWorkRequestBuilder<SeedDatabaseWorker>().build()
-        WorkManager.getInstance(this).enqueue(request)
+        if(sessionManager.userId.value==GUEST_ID) {
+            // only activates if it is in guest mode.
+            // does not activate when logged in since db is overwritten on login
+            // force the database worker to build a new db
+            // in order to check if the weight-db is empty or not and fill it
+            Log.d("test", "home acrivity starting initialization of db")
+            val request = OneTimeWorkRequestBuilder<SeedDatabaseWorker>().build()
+            WorkManager.getInstance(this).enqueue(request)
+        }
         setContent {
             SpeechBuddyTheme(
                 settingsRepository = settingsRepository,

--- a/frontend/app/src/main/java/com/example/speechbuddy/repository/WeightTableRepository.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/repository/WeightTableRepository.kt
@@ -51,13 +51,15 @@ class WeightTableRepository @Inject constructor(
         }
     }
 
-    suspend fun replaceWeightTable(weightRowList: List<WeightRow>) {
-
-        val weightRowEntityList = mutableListOf<WeightRowEntity>()
-        for (weightRow in weightRowList) {
-            weightRowEntityList.add(weightRowMapper.mapFromDomainModel(weightRow))
+    fun replaceWeightTable(weightRowList: List<WeightRow>) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val weightRowEntityList = mutableListOf<WeightRowEntity>()
+            for (weightRow in weightRowList) {
+                weightRowEntityList.add(weightRowMapper.mapFromDomainModel(weightRow))
+            }
+            weightRowDao.upsertAll(weightRowEntityList)
         }
-        weightRowDao.upsertAll(weightRowEntityList)
+
     }
 
     suspend fun getBackupWeightTableRequest(): BackupWeightTableRequest {

--- a/frontend/app/src/main/java/com/example/speechbuddy/viewmodel/MySymbolSettingsViewModel.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/viewmodel/MySymbolSettingsViewModel.kt
@@ -43,6 +43,7 @@ class MySymbolSettingsViewModel @Inject internal constructor(
     private var getSymbolsJob: Job? = null
 
     init {
+        symbolRepository.checkImages()
         getSymbols()
     }
 

--- a/frontend/app/src/main/java/com/example/speechbuddy/worker/SeedDatabaseWorker.kt
+++ b/frontend/app/src/main/java/com/example/speechbuddy/worker/SeedDatabaseWorker.kt
@@ -27,20 +27,24 @@ class SeedDatabaseWorker(
             val database = AppDatabase.getInstance(applicationContext)
 
 
-
             if (!applicationContext.getDatabasePath("speechbuddy-db").exists()) {
+                Log.d("create-db", "no db->initializing db")
                 createWeightTable(database)
             }
             else{ // check if the weight table is filled with 0
                 val currentDb = database.weightRowDao().getAllWeightRows().first()
-                var cnt = 1
+                var cnt = 0
                 for (currentWeightRowEntity in currentDb) {
                     if (currentWeightRowEntity.weights.all{it == 0}){
                         cnt+=1 // count the rows with 0 weights
                     }
                 }
                 if (cnt == currentDb.size){ // if weight table is filled with 0
+                    Log.d("create-db", "empty db->initializing db")
                     createWeightTable(database)
+                }
+                else{
+                    Log.d("create-db", "db exists")
                 }
             }
             


### PR DESCRIPTION
### PR Title: Weight table update logic

#### Related Issue(s):


#### PR Description:
- 백업을 받아오는 속도의 지연에 의해 weight table 초기화 문제를 해결했습니다
- 상징 목록 관리에서 유저가 만든 이미지가 없을 때 이미지가 안 나타나던 문제를 해결했습니다

##### Changes Included:
- [ ] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation

##### Notes for Reviewer:
- 백업을 받아오는 속도가 너무 빠를 경우, 받아온 정보로 weight table을 초기화를 하고 SeedDatabaseWorker가 HomeActivity에서 다시 한번 db를 생성합니다. 이를 해결하기 위해 HomeActivity에서 db 생성은 guest일때만 진행하도록 했습니다.
- SeedDatabaseWorker의 db 생성 로직의 경우 weight table - row에 0이 다 차있을 시 생성하도록 되어있는데 cnt 값이 501로 잘못 설정되어있어 생성이 안되던 경우가 있어 500으로 수정했습니다.
- MySymbolSettingsViewModel에서 init을 실행할때 symbolRepository.checkImages()를 불러서 없는 이미지를 가져오도록 했습니다

#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
